### PR TITLE
Remove `eslint-plugin-import` from `.eslintrc.json`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,6 @@
 		"eslint:recommended",
 		"airbnb",
 		"airbnb/hooks",
-		"plugin:import/recommended",
 		"plugin:prettier/recommended"
 	]
 }


### PR DESCRIPTION
`eslint-plugin-import` is already included by `eslint-config-airbnb`, so its use is extraneous here