### PR TITLE
Fix sorting inputs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+	"plugins": ["simple-import-sort"],
 	"extends": [
 		"eslint:recommended",
 		"google",
@@ -8,6 +9,8 @@
 		"plugin:prettier/recommended"
 	],
 	"rules": {
-		"require-jsdoc": "off"
+		"require-jsdoc": "off",
+		"simple-import-sort/imports": "error",
+		"simple-import-sort/exports": "error"
 	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,7 @@
 
 	"editor.codeActionsOnSave": {
 		/* Fixes lint problems on save (when possible, some problems must be manually fixed) */
-		"source.fixAll": true,
-		"source.organizeImports": true
+		"source.fixAll": true
 	},
 
 	/* prettier */

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"eslint-plugin-prettier": "^4.0.0",
 		"eslint-plugin-react": "^7.27.1",
 		"eslint-plugin-react-hooks": "^4.3.0",
+		"eslint-plugin-simple-import-sort": "^7.0.0",
 		"npm-run-all": "^4.1.5",
 		"postcss-scss": "^4.0.2",
 		"prettier": "^2.4.1",

--- a/src/components/navigation/MyRouter.js
+++ b/src/components/navigation/MyRouter.js
@@ -1,5 +1,6 @@
 import { Button } from '@rmwc/button'
 import Link from 'next/link'
+
 import NavBackButton from './NavBackButton'
 
 export default function MyRouter() {

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,6 +1,7 @@
-import MyRouter from '../components/navigation/MyRouter'
 import '../styles/reset.scss'
 import '../styles/theme.scss'
+
+import MyRouter from '../components/navigation/MyRouter'
 
 export default function App({ Component, pageProps }) {
 	return (

--- a/src/pages/connect.js
+++ b/src/pages/connect.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import Header from '../components/Header'
 
 export default function ConnectPage() {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import Header from '../components/Header'
 
 export default function HomePage() {

--- a/src/pages/project-details.js
+++ b/src/pages/project-details.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import Header from '../components/Header'
 
 export default function ProjectDetails() {

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import React from 'react'
+
 import Header from '../components/Header'
 
 export default function ProjectsPage() {

--- a/src/pages/resources.js
+++ b/src/pages/resources.js
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import Header from '../components/Header'
 
 export default function ResourcesPage() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,11 @@ eslint-plugin-react@^7.27.0, eslint-plugin-react@^7.27.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
 
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
+
 eslint-scope@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"


### PR DESCRIPTION
I made a mistake by enabling `source.organizeImports` in `package.json`. That has been removed in favor of using the fantastic `eslint-plugin-simple-sort-imports` plugin, which does this job

This removes the weird twice "autofix" on save, and now unused imports are no longer removed on save :)

Closes #98